### PR TITLE
Set storage schemas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,10 @@ WORKDIR $GRAPHITE_ROOT
 
 COPY ./carbon.conf.example conf/carbon.conf.example
 COPY ./storage-aggregation.conf conf/storage-aggregation.conf
+COPY ./storage-schemas.conf conf/storage-schemas.conf
 
 # Set up basic config
-RUN cp conf/graphite.wsgi.example webapp/graphite/wsgi.py && \
-    cp conf/storage-schemas.conf.example conf/storage-schemas.conf
+RUN cp conf/graphite.wsgi.example webapp/graphite/wsgi.py
 
 COPY ./local_settings.py /opt/graphite/webapp/graphite
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ Two processes are managed by supervisord:
 #### Configuration
 The example configurations are used in the following places:
 * `conf/graphite.wsgi.example` -> `webapp/graphite/wsgi.py`
-* `conf/storage-schemas.conf.example` -> `conf/storage-schemas.conf`
+
+#### Storage schemas
+The retention schema that is used is 1 minute for 1 day, 5 minutes for 1 year,
+and 1 hour for 5 years.
 
 #### AMQP Configuration
 

--- a/storage-schemas.conf
+++ b/storage-schemas.conf
@@ -1,0 +1,3 @@
+[default]
+pattern = .*
+retentions = 1m:1d,5m:1y,1h:5y


### PR DESCRIPTION
Currently, the storage schemas are set to the default graphite storage schemas, which is one minute for one day. We should probably change this to similar to what we use for vumi go, 1min for 1 day, 5min for 1 year, and 1h for 5 years.
